### PR TITLE
(#57) 재료, 재료-레시피 매핑 테이블 추가

### DIFF
--- a/back-end-api/src/main/java/com/project/egloo/common/StatusCode.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/StatusCode.java
@@ -11,4 +11,7 @@ public class StatusCode {
     public static final int CLIENT_ERROR_REQUEST_TIMEOUT  =   408;
     public static final int CLIENT_ERROR_CONFLICT  =   409;
 
+    public static final int SERVER_INTERNAL_ERROR  =   500;
+
+
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/controller/RecipeController.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/controller/RecipeController.java
@@ -1,0 +1,11 @@
+package com.project.egloo.member.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/recipe")
+public class RecipeController {
+
+}

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/Ingredient.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/Ingredient.java
@@ -1,0 +1,32 @@
+package com.project.egloo.member.domain;
+
+import com.project.egloo.common.ColumnDescription;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Getter
+@Setter
+@Data
+@DynamicInsert
+public class Ingredient {
+
+    @Id @GeneratedValue
+    @ColumnDescription("PK")
+    private Long    id;
+
+    @ColumnDescription("PK")
+    private String name;
+
+    @ColumnDescription("PK")
+    private String ingredientImage;
+
+    @ColumnDescription("PK")
+    private int price;
+}

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/IngredientRecipeIdClass.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/IngredientRecipeIdClass.java
@@ -1,0 +1,15 @@
+package com.project.egloo.member.domain;
+
+import lombok.Data;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+
+@Getter
+@Data
+public class IngredientRecipeIdClass implements Serializable {
+
+    private Recipe recipe;
+    private Ingredient ingredient;
+}

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/IngredientRecipeMapping.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/IngredientRecipeMapping.java
@@ -1,0 +1,43 @@
+package com.project.egloo.member.domain;
+
+import com.project.egloo.common.ColumnDescription;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Getter
+@Setter
+@Data
+@DynamicInsert
+@IdClass(IngredientRecipeIdClass.class)
+public class IngredientRecipeMapping {
+
+
+    @ManyToOne
+    @Id
+    @ColumnDescription("FK 레시피 ID")
+    private Recipe recipe;
+
+    @ManyToOne
+    @Id
+    @ColumnDescription("FK 재료 ID")
+    private Ingredient ingredient;
+
+    @ManyToOne
+    @ColumnDescription("FK 카테고리 ID")
+    private Category category;
+
+    @ColumnDescription("수량")
+    private int quantity;
+
+    @ColumnDescription("단위")
+    @Enumerated(EnumType.STRING)
+    private Unit unit;
+
+    @ColumnDescription("필수 여부")
+    private boolean checkIngredient;
+}

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/Unit.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/Unit.java
@@ -1,0 +1,5 @@
+package com.project.egloo.member.domain;
+
+public enum Unit {
+    GRAM, MILLILITER
+}


### PR DESCRIPTION
#57 
entity 추가
- 재료
- 재료, 레시피 매핑테이블

class 추가
- RecipeController
  - 레시피 컨트롤러
- Ingredient
- IngredientRecipeMapping
  - 재료, 레시피 매핑테이블 Entity
- IngredientRecipeIdClass
  - JPA Entity에서 @Id 선언이 필수조건으로 설정되어 있어 외래키만 가지고 있는 테이블 선언이 불가합니다. 레시피ID, 재료ID는 중복값이 들어갈 수 있으나 서로 조합을 했을때는 중복된 값이 존재할 수 없어 복합키 @Id를 선언해서 JPA @Entity를 사용할 수 있도록 수정했습니다.

- Unit
  - GRAM, MILLILITER만 추가하였습니다.

수정
- StatusCode, 500 internal server error 추가