### PR TITLE
(#31) 레시피 검색 기능

### DIFF
--- a/back-end-api/src/main/java/com/project/egloo/member/controller/RecipeController.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/controller/RecipeController.java
@@ -1,11 +1,25 @@
 package com.project.egloo.member.controller;
 
+import com.project.egloo.member.service.RecipeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 
 @RestController
 @RequestMapping("/recipe")
 public class RecipeController {
 
+    @Autowired
+    private RecipeService recipeService;
+
+    @GetMapping("/getRecipeByIngredients")
+    public HashMap recipeByIngredients(@RequestParam ArrayList ingredient){
+        return recipeService.getRecipeByIngredients(ingredient);
+    }
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/repository/IngredientRecipeMappingRepository.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/repository/IngredientRecipeMappingRepository.java
@@ -1,0 +1,13 @@
+package com.project.egloo.member.repository;
+
+import com.project.egloo.member.domain.IngredientRecipeIdClass;
+import com.project.egloo.member.domain.IngredientRecipeMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface IngredientRecipeMappingRepository extends JpaRepository<IngredientRecipeMapping, IngredientRecipeIdClass> {
+    List<IngredientRecipeMapping> findByIngredient_id(Long ingredient_id);
+}

--- a/back-end-api/src/main/java/com/project/egloo/member/service/RecipeService.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/service/RecipeService.java
@@ -1,7 +1,49 @@
 package com.project.egloo.member.service;
 
+import com.project.egloo.common.StatusCode;
+import com.project.egloo.member.domain.IngredientRecipeMapping;
+import com.project.egloo.member.repository.IngredientRecipeMappingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.*;
 
 @Service
 public class RecipeService {
+
+    @Autowired
+    private IngredientRecipeMappingRepository ingredientRecipeMappingRepository;
+
+    public HashMap getRecipeByIngredients(ArrayList lis) {
+        ArrayList intersection = new ArrayList();
+        for(int i=0; i < lis.size(); i++){
+            List mappingList =  ingredientRecipeMappingRepository.findByIngredient_id(Long.parseLong((String) lis.get(i)));
+            List recipeNames = new ArrayList();
+            for(int j=0; j < mappingList.size(); j++){
+                IngredientRecipeMapping map = (IngredientRecipeMapping) mappingList.get(j);
+                recipeNames.add(map.getRecipe().getName());
+            }
+            intersection.add(recipeNames);
+        }
+        return  response(intersection(intersection));
+    }
+
+    public HashSet intersection(ArrayList inputArrays)
+    {
+        HashSet intersectionSet = new HashSet((Collection) inputArrays.get(0));
+        for (int i = 1; i < inputArrays.size(); i++)
+        {
+            HashSet innerset = new HashSet((Collection) inputArrays.get(i));
+            intersectionSet.retainAll(innerset);
+        }
+        return intersectionSet;
+    }
+
+    public HashMap response(Object object){
+        HashMap res = new HashMap();
+        res.put("code", StatusCode.SUCCESS_OK);
+        res.put("msg",object);
+        res.put("errors","");
+        return res;
+    }
 }


### PR DESCRIPTION
#31 레시피 검색기능

class 추가
- IngredientRecipeMappingRepository.class
  - IngredientRecipeMapping 테이블 매핑 repository

기능추가
- /recipe/getRecipeByIngredients URL Get요청 추가
  - 레시피 검색 기능 요청 URL이며 재료 id리스트를 입력받는 list 파라미터 입니다.

- 재료 검색기능 추가
  - 재료 ID마다 요리 가능한 레시피 검색합니다.
  - 재료마다 검색된 리스트를 가지고 있으며 추출된 리스트들의 교집합을 통해 추천 레시피를 제공합니다.
  - ex)

||재료|레시피|
|------|---|---|
|1|김치|[김치찌개, 김치볶음밥, 김치전]|
|2|돼지고기|[김치찌개, 김치볶음밥, 삼겹살, 수육]|
|3|쌀|[김치볶음밥, 콩나물비빔밥]|

---
결과 
||추천 레시피|
|------|---|
|1|[김치볶음밥]|


