### PR TITLE
(#35) feature global exception

### DIFF
--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/AuthException.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/AuthException.java
@@ -1,0 +1,7 @@
+package com.project.egloo.common.exceptions;
+
+public class AuthException extends BusinessException{
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/BusinessException.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/BusinessException.java
@@ -1,0 +1,10 @@
+package com.project.egloo.common.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/EntityNotFoundException.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.project.egloo.common.exceptions;
+
+public class EntityNotFoundException extends BusinessException {
+	public EntityNotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorCode.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorCode.java
@@ -1,0 +1,43 @@
+package com.project.egloo.common.exceptions;
+
+import lombok.Getter;
+
+
+@Getter
+public enum ErrorCode {
+
+//    server
+    INTERNAL_SERVER_ERROR(500, "C_001", "서버가 터졌습니다."),
+    METHOD_NOT_ALLOWED(405, "C_002", "Api는 열려있으나 메소드는 사용 불가합니다."),
+    INVALID_INPUT_VALUE(400, "C_003", "적절하지 않은 요청 값입니다."),
+    INVALID_TYPE_VALUE(400, "C_004", "요청 값의 타입이 잘못되었습니다."),
+    ENTITY_NOT_FOUND(400, "C_005", "지정한 Entity를 찾을 수 없습니다."),
+
+//    auth
+    AUTH_ERROR(400, "AU_001", "인증 관련 오류가 발생했습니다."),
+    DUPLICATED_EMAIL(400, "AU_002", "이미 존재하는 아이디입니다."),
+    DUPLICATED_NICKNAME(400, "AU_003", "이미 존재하는 닉네임입니다."),
+    UNAUTHORIZED_REDIRECT_URI(400, "AU_004", "인증되지 않은 REDIRECT_URI입니다."),
+    BAD_LOGIN(400, "AU_005", "잘못된 아이디 또는 패스워드입니다."),
+    UNAUTHORIZED_MEMBER(400,"AU_006","존재하지않는 유저입니다."),
+    CHECK_REVIEW(200,"AU_008","이미 작성된 리뷰가 있습니다."),
+    CHECK_ANSWER(200,"AU_009","이미 작성된 답글가 있습니다."),
+    NOT_FOUND_IMAGE(400,"AU_007","이미지 관련 오류가 발생했습니다."),
+
+//    register
+    BAD_REGISTER(400,"RG_001","회원가입에 필수적으로 필요한 데이터가 충족되지 않았습니다."),
+
+//    recipe
+    BAD_RECIPE(400 ,"RC_001","필수 레시피 데이터 값이 입력되지 않았습니다."),
+    DUPLICATED_RECIPE(400,"RE_002","이미 존재하는 레시피입니다.");
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorResponse.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorResponse.java
@@ -1,0 +1,84 @@
+package com.project.egloo.common.exceptions;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+	private String message;
+
+	private List<FieldError> errors;
+
+	private String code;
+
+	private ErrorResponse(ErrorCode code, List<FieldError> errors) {
+		this.message = code.getMessage();
+		this.errors = errors;
+		this.code = code.getCode();
+	}
+
+	private ErrorResponse(ErrorCode code) {
+		this.message = code.getMessage();
+		this.code = code.getCode();
+		this.errors = new ArrayList<>();
+	}
+
+	public static ErrorResponse of(ErrorCode code, BindingResult bindingResult) {
+		return new ErrorResponse(code, FieldError.of(bindingResult));
+	}
+
+	public static ErrorResponse of(ErrorCode code) {
+		return new ErrorResponse(code);
+	}
+
+	public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+		String value = Optional.ofNullable(e.getValue())
+			.map(Object::toString)
+			.orElse("");
+
+		List<FieldError> errors = FieldError.of(
+			e.getName(), value, e.getErrorCode());
+		return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class FieldError {
+		private String field;
+		private String value;
+		private String reason;
+
+		private FieldError(String field, String value, String reason) {
+			this.field = field;
+			this.value = value;
+			this.reason = reason;
+		}
+
+		public static List<FieldError> of(String field, String value, String reason) {
+			List<FieldError> fieldErrors = new ArrayList<>();
+			fieldErrors.add(new FieldError(field, value, reason));
+			return fieldErrors;
+		}
+
+		private static List<FieldError> of(BindingResult bindingResult) {
+			List<org.springframework.validation.FieldError> fieldErrors = bindingResult
+				.getFieldErrors();
+			return fieldErrors.stream()
+				.map(error -> new FieldError(
+					error.getField(),
+					error.getRejectedValue() == null ? "" :
+						error.getRejectedValue().toString(),
+					error.getDefaultMessage()))
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/GlobalExceptionHandler.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package com.project.egloo.common.exceptions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE,
+			e.getBindingResult());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+		MethodArgumentTypeMismatchException e) {
+		ErrorResponse response = ErrorResponse.of(e);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+		HttpRequestMethodNotSupportedException e) {
+		ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+		return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
+	@ExceptionHandler(BusinessException.class)
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		ErrorResponse response = ErrorResponse.of(errorCode);
+		return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	protected ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse response = ErrorResponse.of(ErrorCode.AUTH_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(IllegalStateException.class)
+	protected ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
+		log.error(e.getMessage(), e);
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error(e.getMessage(), e);
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/InvalidValueException.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/InvalidValueException.java
@@ -1,0 +1,7 @@
+package com.project.egloo.common.exceptions;
+
+public class InvalidValueException extends BusinessException {
+	public InvalidValueException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
- (#35) 주요 Global Exception Configuration

//    server
    INTERNAL_SERVER_ERROR(500, "C_001", "서버가 터졌습니다."),
    METHOD_NOT_ALLOWED(405, "C_002", "Api는 열려있으나 메소드는 사용 불가합니다."),
    INVALID_INPUT_VALUE(400, "C_003", "적절하지 않은 요청 값입니다."),
    INVALID_TYPE_VALUE(400, "C_004", "요청 값의 타입이 잘못되었습니다."),
    ENTITY_NOT_FOUND(400, "C_005", "지정한 Entity를 찾을 수 없습니다."),

//    auth
    AUTH_ERROR(400, "AU_001", "인증 관련 오류가 발생했습니다."),
    DUPLICATED_EMAIL(400, "AU_002", "이미 존재하는 아이디입니다."),
    DUPLICATED_NICKNAME(400, "AU_003", "이미 존재하는 닉네임입니다."),
    UNAUTHORIZED_REDIRECT_URI(400, "AU_004", "인증되지 않은 REDIRECT_URI입니다."),
    BAD_LOGIN(400, "AU_005", "잘못된 아이디 또는 패스워드입니다."),
    UNAUTHORIZED_MEMBER(400,"AU_006","존재하지않는 유저입니다."),
    CHECK_REVIEW(200,"AU_008","이미 작성된 리뷰가 있습니다."),
    CHECK_ANSWER(200,"AU_009","이미 작성된 답글가 있습니다."),
    NOT_FOUND_IMAGE(400,"AU_007","이미지 관련 오류가 발생했습니다."),

//    register
    BAD_REGISTER(400,"RG_001","회원가입에 필수적으로 필요한 데이터가 충족되지 않았습니다."),

//    recipe
    BAD_RECIPE(400 ,"RC_001","필수 레시피 데이터 값이 입력되지 않았습니다."),
    DUPLICATED_RECIPE(400,"RE_002","이미 존재하는 레시피입니다.");

- BusinessException 추가, 비즈니스 로직 설정 후 설정 예정 
  - 예) 레시피 결제, 레시피 사용순서 등