### PR TITLE
(#53) SpringSecurity enhancement by member

### DIFF
--- a/back-end-api/src/main/java/com/project/egloo/common/AuthMember.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/AuthMember.java
@@ -1,0 +1,12 @@
+package com.project.egloo.common;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : member")
+@Documented
+public @interface AuthMember {
+}

--- a/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorCode.java
+++ b/back-end-api/src/main/java/com/project/egloo/common/exceptions/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     SUCCESS(200,"AU_000","요청에 성공하였습니다."),
     AUTH_ERROR(400, "AU_001", "인증 관련 오류가 발생했습니다."),
     DUPLICATED_EMAIL(400, "AU_002", "이미 존재하는 아이디입니다."),
-    DUPLICATED_NICKNAME(400, "AU_003", "이미 존재하는 닉네임입니다."),
+    DUPLICATED_ID(400, "AU_003", "이미 존재하는 아이디입니다."),
     UNAUTHORIZED_REDIRECT_URI(400, "AU_004", "인증되지 않은 REDIRECT_URI입니다."),
     BAD_LOGIN(400, "AU_005", "잘못된 아이디 또는 패스워드입니다."),
     UNAUTHORIZED_MEMBER(400,"AU_006","존재하지않는 유저입니다."),

--- a/back-end-api/src/main/java/com/project/egloo/config/security/UserPrincipal.java
+++ b/back-end-api/src/main/java/com/project/egloo/config/security/UserPrincipal.java
@@ -1,6 +1,7 @@
 package com.project.egloo.config.security;
 
 import com.project.egloo.member.domain.Member;
+import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,6 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+@Data
 public class UserPrincipal implements UserDetails {
 	private Member member;
 

--- a/back-end-api/src/main/java/com/project/egloo/member/controller/AuthController.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.project.egloo.member.controller;
 
+import com.project.egloo.common.AuthMember;
 import com.project.egloo.config.jwt.JwtFilter;
 import com.project.egloo.config.jwt.TokenProvider;
 import com.project.egloo.member.dto.request.LoginRequest;

--- a/back-end-api/src/main/java/com/project/egloo/member/controller/MemberController.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/controller/MemberController.java
@@ -1,24 +1,29 @@
 package com.project.egloo.member.controller;
 
-import com.project.egloo.member.domain.Member;
+import com.project.egloo.member.dto.request.SignUpRequest;
+import com.project.egloo.member.dto.response.SignUpResponse;
 import com.project.egloo.member.service.MemberService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping(value = "/user", produces = {MediaType.APPLICATION_JSON_VALUE}, consumes = {MediaType.APPLICATION_JSON_VALUE})
 public class MemberController {
 
-    @Autowired
-    private MemberService memberService;
+    private final MemberService memberService;
 
     @PostMapping("/signup")
-    public Object memberSignUp(@Valid Member member, Errors errors) {
-        return memberService.memberSignUP(member, errors);
+    @PreAuthorize("isAnonymous()")
+    public ResponseEntity<SignUpResponse> memberSignUp(@Valid SignUpRequest signUpRequest, Errors errors) throws Exception {
+        SignUpResponse signUpResponse = memberService.memberSignUP(signUpRequest, errors);
+        return ResponseEntity.ok(signUpResponse);
     }
 
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/Member.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
-    @Column(columnDefinition = "VARCHAR2")
+    @Column(columnDefinition = "VARCHAR")
     @ColumnDescription("PK")
     private UUID id;
     

--- a/back-end-api/src/main/java/com/project/egloo/member/domain/Member.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/domain/Member.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.UUID;
 
 @Entity
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Getter
 @Setter
@@ -26,21 +25,17 @@ public class Member {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
-    @Column(columnDefinition = "BINARY(16)")
+    @Column(columnDefinition = "VARCHAR2")
     @ColumnDescription("PK")
     private UUID id;
     
     @Column(unique = true)
-    @NotNull@NotBlank
     @ColumnDescription("유저 아이디")
     private String userId;
     
     @ColumnDescription("유저 이름")
     private String name;
 
-    @NotNull@NotBlank
-    @Length(min = 8, max = 20)
-    @Pattern(regexp = "^((?=.*[a-z0-9])(?=.*[A-Z]).{8,20})|((?=.*[a-z0-9])(?=.*[^a-zA-Z0-9가-힣]).{8,20})$")
     @ColumnDescription("비밀번호")
     private String password;
 
@@ -49,7 +44,6 @@ public class Member {
     @ColumnDescription("유저 회원가입 경로")
     private Social social;
 
-    @NotNull@NotBlank
     @ColumnDescription("유저 휴대폰 번호")
     private String phoneNo;
 
@@ -67,6 +61,19 @@ public class Member {
     private MemberRole role;
 
     public Member(String subject, String s, Collection<? extends GrantedAuthority> authorities) {
+    }
+
+    @Builder
+    public Member(String userId, String name, String password, Social social, String phoneNo, Gender gender, String email, String address, MemberRole role) {
+        this.userId = userId;
+        this.name = name;
+        this.password = password;
+        this.social = social;
+        this.phoneNo = phoneNo;
+        this.gender = gender;
+        this.email = email;
+        this.address = address;
+        this.role = role;
     }
 
     public String roleName(){

--- a/back-end-api/src/main/java/com/project/egloo/member/dto/request/SignUpRequest.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/dto/request/SignUpRequest.java
@@ -1,4 +1,47 @@
 package com.project.egloo.member.dto.request;
 
+import com.project.egloo.member.domain.Gender;
+import com.project.egloo.member.domain.Social;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@AllArgsConstructor
 public class SignUpRequest {
+
+    @NotBlank
+    private String userId;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Length(min = 8, max = 20)
+    @Pattern(regexp = "^((?=.*[a-z0-9])(?=.*[A-Z]).{8,20})|((?=.*[a-z0-9])(?=.*[^a-zA-Z0-9가-힣]).{8,20})$")
+    private String password;
+
+    @NotBlank
+    @Enumerated(EnumType.STRING)
+    private Social social;
+
+    @NotBlank
+    private String phoneNo;
+
+    @NotBlank
+    private Gender gender;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String address;
+
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/dto/response/SignUpResponse.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/dto/response/SignUpResponse.java
@@ -1,18 +1,18 @@
 package com.project.egloo.member.dto.response;
 
-import java.util.HashMap;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
 public class SignUpResponse {
-    private int code;
 
-    public SignUpResponse(int code) {
-        this.code = code;
-    }
+    private UUID uuid;
 
-    public HashMap response(Object msg){
-        HashMap response = new HashMap();
-        response.put("code",this.code);
-        response.put("msg", msg);
-        return response;
+    public static SignUpResponse of(UUID id){
+        return new SignUpResponse(id);
     }
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/dto/response/TokenResponse.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/dto/response/TokenResponse.java
@@ -3,7 +3,6 @@ package com.project.egloo.member.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/back-end-api/src/main/java/com/project/egloo/member/repository/MemberRepository.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/repository/MemberRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member,Long>{
-    Optional<Member> findByUserIdAndPassword(String userId, String password);
     Optional<Member> findByUserId(String userId);
+    Optional<Member> findByEmail(String email);
 }

--- a/back-end-api/src/main/java/com/project/egloo/member/service/MemberService.java
+++ b/back-end-api/src/main/java/com/project/egloo/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.project.egloo.member.service;
 
-import com.project.egloo.common.ResponseEntityObject;
 import com.project.egloo.common.exceptions.AuthException;
 import com.project.egloo.common.exceptions.ErrorCode;
 import com.project.egloo.member.domain.Member;
@@ -12,15 +11,16 @@ import com.project.egloo.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
 
-import javax.transaction.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRespository;
+    private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -28,8 +28,8 @@ public class MemberService {
         if (errors.hasErrors()) {
             throw new Exception();
         }
-        memberRespository.findByUserId(signUpRequest.getUserId()).orElseThrow(()->new AuthException(ErrorCode.DUPLICATED_ID));
-        memberRespository.findByEmail(signUpRequest.getEmail()).orElseThrow(()->new AuthException(ErrorCode.DUPLICATED_EMAIL));
+        memberRepository.findByUserId(signUpRequest.getUserId()).orElseThrow(()->new AuthException(ErrorCode.DUPLICATED_ID));
+        memberRepository.findByEmail(signUpRequest.getEmail()).orElseThrow(()->new AuthException(ErrorCode.DUPLICATED_EMAIL));
 
         Member member = Member.builder()
                 .email(signUpRequest.getEmail())
@@ -42,7 +42,7 @@ public class MemberService {
 
         member.setPassword(passwordEncoder.encode(member.getPassword()));
 
-        memberRespository.save(member);
+        memberRepository.save(member);
         return SignUpResponse.of(member.getId());
     }
 }


### PR DESCRIPTION
- 현재 로그인한 유저의 정보를 가져오는 커스텀 어노테이션을 추가했습니다.
```
@AuthMember Member member

member.getUserId();
```
위와 같은 방식으로 사용하실 수 있습니다.
ElementType.PARAMETER, ElementType.TYPE으로 설정하였습니다.

- SignUp 과 관련하여 데이터 방식을 DTO로 request와 response가 이뤄지도록 설정했습니다.
  - request에서는 validation을 적용하고 Entity에서 걸린 validation은 삭제했습니다.
  
- 기존의 Controller return type을 변경했습니다.
  - ResponseEntity로 적용하여 진행했습니다. 

- GlobalException 처리하는 과정에서 코드 리팩토링을 진행했습니다.
```
memberRespository.findByUserId(signUpRequest.getUserId()).orElseThrow(()->new AuthException(ErrorCode.DUPLICATED_ID));
```
위와같이 필요한 Exception을 가져와서 처리할 수 도 있고 중요한 부분같은 경우는 throws를 GlobalException에 처리된 부분을 가져와 쓸 수 있습니다. (이 부분은 추후 논의를 통해 추가 Exception이 추가될 수 있습니다.)

- 회원가입시 비밀번호의 암호화를 passwordEncoder를 이용하여 암호화하여 저장합니다.